### PR TITLE
[feat] 3일차 Entity 직접 노출 예시와 DTO로 바꿔보기.

### DIFF
--- a/jiyoul/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jiyoul/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -11,6 +11,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
@@ -37,8 +38,19 @@ public class OrderApiController {
     @GetMapping("/api/v2/orders")
     public List<OrderDto> ordersV2() {
         List<Order> orders = orderRepository.findAllByString(new OrderSearch());
-        List<OrderDto> result = orders.stream().map(o -> new OrderDto(o)).collect(Collectors.toList());
-        return result;
+        return orders.stream().map(o -> new OrderDto(o)).collect(Collectors.toList());
+    }
+
+    @GetMapping("/api/v3/orders")
+    public List<OrderDto> ordersV3() {
+        List<Order> orderList = orderRepository.findAllWithItem();
+        return orderList.stream().map(o-> new OrderDto(o)).collect(Collectors.toList());
+    }
+
+    @GetMapping("/api/v3.1/orders")
+    public List<OrderDto> ordersV3_page(@RequestParam(value = "offset", defaultValue = "0") int offset, @RequestParam(value = "limit", defaultValue = "100") int limit) {
+        List<Order> orderList = orderRepository.findAllWithMemberDelivery(offset, limit);
+        return orderList.stream().map(o-> new OrderDto(o)).collect(Collectors.toList());
     }
 
     @Getter

--- a/jiyoul/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jiyoul/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 @RestController
 @RequiredArgsConstructor
 public class OrderSimpleApiController {
-
     private final OrderRepository orderRepository;
     private final OrderSimpleQueryRepository orderSimpleQueryRepository;
 

--- a/jiyoul/jpashop/src/main/java/jpabook/jpashop/repository/order/OrderRepository.java
+++ b/jiyoul/jpashop/src/main/java/jpabook/jpashop/repository/order/OrderRepository.java
@@ -95,4 +95,18 @@ public class OrderRepository {
         return em.createQuery("select o from Order o join fetch o.member m join fetch o.delivery d", Order.class).getResultList();
     }
 
+    public List<Order> findAllWithItem() {
+        return em.createQuery("select distinct o from Order o join fetch o.member m join fetch o.delivery d join fetch o.orderItems oi join fetch oi.item i", Order.class).getResultList();
+    }
+
+    /**
+     * to One 관계는 페이징이 문제없이 잘동작함.
+     */
+    public List<Order> findAllWithMemberDelivery(int offset, int limit) {
+        return em.createQuery("select o from Order o join fetch o.member m join fetch o.delivery d", Order.class)
+                .setFirstResult(offset)
+                .setMaxResults(limit)
+                .getResultList();
+    }
+
 }

--- a/jiyoul/jpashop/src/main/resources/application.properties
+++ b/jiyoul/jpashop/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.datasource.driver-class-name= org.h2.Driver
 
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.default_batch_fetch_size=100
 
 logging.level.org.hibernate.SQL=Debug
 logging.level.org.hibernate.type=trace


### PR DESCRIPTION
오늘은 Entity를 api 통신할때 Response에 노출하면 위험 하다는 사실을 처음 알게 되었다.
보통 Entity로 통신하지 않고 항상 DTO로 통신을 하고 있었지만 오늘 그러한 이유를 알게 되었다.
Entity로 통신을 하게 되면 예기치 않는 테이블들도 Join해서 가져올수 있고 1번만 호출될 로직도
1+n번 호출 되게 된다는것을 깨달았고 그를 예방하기 위해 DTO로 변환하는법도 배웠다.