### PR TITLE
 [feat] 6일차 querydsl 및 OSIV로 성능 최적화 공부

### DIFF
--- a/jiyoul/jpashop/build.gradle
+++ b/jiyoul/jpashop/build.gradle
@@ -2,16 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.6.7'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
-}
-
-apply plugin: "com.ewerk.gradle.plugins.querydsl"
-apply plugin: 'io.spring.dependency-management'
-
-//querydsl 추가
-buildscript {
-	dependencies {
-		classpath("gradle.plugin.com.ewerk.gradle.plugins:querydslplugin:1.0.10")
-	}
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'jpabook'

--- a/jiyoul/jpashop/build.gradle
+++ b/jiyoul/jpashop/build.gradle
@@ -4,6 +4,16 @@ plugins {
 	id 'java'
 }
 
+apply plugin: "com.ewerk.gradle.plugins.querydsl"
+apply plugin: 'io.spring.dependency-management'
+
+//querydsl 추가
+buildscript {
+	dependencies {
+		classpath("gradle.plugin.com.ewerk.gradle.plugins:querydslplugin:1.0.10")
+	}
+}
+
 group = 'jpabook'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
@@ -32,8 +42,35 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'
+
+	//querydsl 추가
+	implementation 'com.querydsl:querydsl-jpa'
+	//querydsl 추가
+	implementation 'com.querydsl:querydsl-apt'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+//querydsl 추가
+//def querydslDir = 'src/main/generated'
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+	library = "com.querydsl:querydsl-apt"
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main {
+		java {
+			srcDirs = ['src/main/java', querydslDir]
+		}
+	}
+}
+compileQuerydsl{
+	options.annotationProcessorPath = configurations.querydsl
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
 }


### PR DESCRIPTION
spring.jpa.open-in-view:false  => OSIV 종료
OSIV 는 admin같은 서버에선 키고 사용하느것이 좋고,
고객 서비스 실시간API에서 트래픽이 많아서 OSIV를 끄고 사용해야된다.
(데이터 커넥션이 다 날라감)